### PR TITLE
Simplify .gitignore for WebExtension project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,4 @@
-# dependencies
-node_modules
-
-# testing
-/coverage
-
-# production
-/build
-
-# misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
 *.zip
+*.xpi
+web-ext-artifacts/


### PR DESCRIPTION
## Summary

- Replace boilerplate Node/React `.gitignore` with minimal WebExtension-relevant patterns
- Only ignores: `.DS_Store`, `*.zip`, `*.xpi`, `web-ext-artifacts/`