### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/xiaoClock/manifest.json
+++ b/xiaoClock/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "xiao-clock",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A simple and small text based clock which sits in the toolbar. Ideal for fullscreen use of Firefox.",
   "permissions": ["menus"],
   "icons": {


### PR DESCRIPTION
Version bump from 0.5.0 → 0.6.0 to release the timezone feature (published version is 0.5.2).